### PR TITLE
Testing lowercase literals for JSON.

### DIFF
--- a/tests/src/Anorgan/QueryLanguage/ConditionTest.php
+++ b/tests/src/Anorgan/QueryLanguage/ConditionTest.php
@@ -57,7 +57,7 @@ class ConditionTest extends \PHPUnit_Framework_TestCase
      */
     public function testNormalizeValueConvertsJsonToArray()
     {
-        $condition = new Condition('field', '=', '[1, "test", NULL]');
+        $condition = new Condition('field', '=', '[1, "test", null]');
         $parts = $condition->toArray();
         $this->assertEquals(array(1, 'test', null), $parts['value']);
     }


### PR DESCRIPTION
I saw your post on Reddit, I did some looking around your code and it may be because of the uppercase NULL literal in the JSON string.

For more information, see http://php.net/manual/en/migration56.incompatible.php#migration56.incompatible.json-decode
